### PR TITLE
fix enabled problem

### DIFF
--- a/src/add.js
+++ b/src/add.js
@@ -37,7 +37,7 @@ function add(down) {
 	showEnable();
         return 0;
     }
-    if (!enabled) {
+    if (enabled==0) {
         //var notification = new Notification("添加到aria2当前暂停", {body: "如需启用点击工具栏中图标"});
         return 0;
     }


### PR DESCRIPTION
在localstorage中存放的enabled，取出时会得到字符串类型的‘0’或者‘1’。
原本的判断是否接管下载的代码部分 !enabled会一直返回false。所以无论是否点击图标都不会停止接管下载。
做了很微小的改动……